### PR TITLE
Use default admin role for unpausing and add/remove minters

### DIFF
--- a/script/DeployWstETHBridgeL1.s.sol
+++ b/script/DeployWstETHBridgeL1.s.sol
@@ -18,8 +18,7 @@ contract DeployWstETHBridgeL1 is Script {
   address adminAddress = 0xf694C9e3a34f5Fa48b6f3a0Ff186C1c6c4FcE904;
   address emergencyRoleAddress = 0xf694C9e3a34f5Fa48b6f3a0Ff186C1c6c4FcE904;
   address originTokenAddress = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
-  address polygonZkEVMBridgeAddress =
-    0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe;
+  address polygonZkEVMBridgeAddress = 0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe;
 
   address wrappedTokenAddress;
   address counterpartContract;
@@ -27,14 +26,11 @@ contract DeployWstETHBridgeL1 is Script {
   uint32 counterpartNetwork = 1; // Ethereum -> zkEVM
 
   // CREATE3 Factory
-  ICREATE3Factory factory =
-    ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
+  ICREATE3Factory factory = ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
 
   function setUp() public {
-    wrappedTokenAddress =
-      factory.getDeployed(deployerAddress, keccak256(bytes("WstETHWrapped")));
-    counterpartContract =
-      factory.getDeployed(deployerAddress, keccak256(bytes("WstETHBridgeL2")));
+    wrappedTokenAddress = factory.getDeployed(deployerAddress, keccak256(bytes("WstETHWrapped")));
+    counterpartContract = factory.getDeployed(deployerAddress, keccak256(bytes("WstETHBridgeL2")));
   }
 
   function run() public returns (address proxy) {
@@ -54,9 +50,8 @@ contract DeployWstETHBridgeL1 is Script {
       counterpartNetwork
     );
     bytes32 salt = keccak256(bytes("WstETHBridgeL1"));
-    bytes memory creationCode = abi.encodePacked(
-      type(UUPSProxy).creationCode, abi.encode(address(wstETHBridgeL1), data)
-    );
+    bytes memory creationCode =
+      abi.encodePacked(type(UUPSProxy).creationCode, abi.encode(address(wstETHBridgeL1), data));
     proxy = factory.deploy(salt, creationCode);
 
     vm.stopBroadcast();

--- a/script/DeployWstETHBridgeL2.s.sol
+++ b/script/DeployWstETHBridgeL2.s.sol
@@ -17,8 +17,7 @@ contract DeployWstETHBridgeL2 is Script {
   address deployerAddress = 0x17C8acE2dBa0d3060a7400B5AF79094a714d1537;
   address adminAddress = 0x2be7b3e7b9BFfbB38B85f563f88A34d84Dc99c9f;
   address emergencyRoleAddress = 0x2be7b3e7b9BFfbB38B85f563f88A34d84Dc99c9f;
-  address polygonZkEVMBridgeAddress =
-    0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe;
+  address polygonZkEVMBridgeAddress = 0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe;
   address originTokenAddress = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
 
   address wrappedTokenAddress;
@@ -27,14 +26,11 @@ contract DeployWstETHBridgeL2 is Script {
   uint32 counterpartNetwork = 0; // zkEVM -> Ethereum
 
   // CREATE3 Factory
-  ICREATE3Factory factory =
-    ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
+  ICREATE3Factory factory = ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
 
   function setUp() public {
-    wrappedTokenAddress =
-      factory.getDeployed(deployerAddress, keccak256(bytes("WstETHWrapped")));
-    counterpartContract =
-      factory.getDeployed(deployerAddress, keccak256(bytes("WstETHBridgeL1")));
+    wrappedTokenAddress = factory.getDeployed(deployerAddress, keccak256(bytes("WstETHWrapped")));
+    counterpartContract = factory.getDeployed(deployerAddress, keccak256(bytes("WstETHBridgeL1")));
   }
 
   function run() public returns (address proxy) {
@@ -54,9 +50,8 @@ contract DeployWstETHBridgeL2 is Script {
       counterpartNetwork
     );
     bytes32 salt = keccak256(bytes("WstETHBridgeL2"));
-    bytes memory creationCode = abi.encodePacked(
-      type(UUPSProxy).creationCode, abi.encode(address(wstETHBridgeL2), data)
-    );
+    bytes memory creationCode =
+      abi.encodePacked(type(UUPSProxy).creationCode, abi.encode(address(wstETHBridgeL2), data));
     proxy = factory.deploy(salt, creationCode);
 
     vm.stopBroadcast();

--- a/script/DeployWstETHWrapped.s.sol
+++ b/script/DeployWstETHWrapped.s.sol
@@ -20,8 +20,7 @@ contract DeployWstETHWrapped is Script {
   address wstETHBridgeAddress = 0xDB5D9c10FD2a92692DB51853e06058EE0436d69B;
 
   // CREATE3 Factory
-  ICREATE3Factory factory =
-    ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
+  ICREATE3Factory factory = ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
 
   function run() public returns (address proxy) {
     uint256 deployerPrivateKey = uint256(vm.envBytes32("PRIVATE_KEY"));
@@ -29,16 +28,10 @@ contract DeployWstETHWrapped is Script {
     vm.startBroadcast(deployerPrivateKey);
 
     WstETHWrapped wstETHWrapped = new WstETHWrapped();
-    bytes memory data = abi.encodeWithSelector(
-      WstETHWrapped.initialize.selector,
-      adminAddress,
-      emergencyRoleAddress,
-      wstETHBridgeAddress
-    );
+    bytes memory data =
+      abi.encodeWithSelector(WstETHWrapped.initialize.selector, adminAddress, emergencyRoleAddress, wstETHBridgeAddress);
     bytes32 salt = keccak256(bytes("WstETHWrapped"));
-    bytes memory creationCode = abi.encodePacked(
-      type(UUPSProxy).creationCode, abi.encode(address(wstETHWrapped), data)
-    );
+    bytes memory creationCode = abi.encodePacked(type(UUPSProxy).creationCode, abi.encode(address(wstETHWrapped), data));
     proxy = factory.deploy(salt, creationCode);
 
     vm.stopBroadcast();

--- a/script/GetConstructorArgsWsETHBridgeL2UUPSProxy.s.sol
+++ b/script/GetConstructorArgsWsETHBridgeL2UUPSProxy.s.sol
@@ -13,8 +13,7 @@ contract GetConstructorArgsWsETHBridgeL2UUPSProxy is Script {
   address deployerAddress = 0x17C8acE2dBa0d3060a7400B5AF79094a714d1537;
   address adminAddress = 0x2be7b3e7b9BFfbB38B85f563f88A34d84Dc99c9f;
   address emergencyRoleAddress = 0x2be7b3e7b9BFfbB38B85f563f88A34d84Dc99c9f;
-  address polygonZkEVMBridgeAddress =
-    0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe;
+  address polygonZkEVMBridgeAddress = 0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe;
   address originTokenAddress = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
 
   address wrappedTokenAddress;
@@ -23,14 +22,11 @@ contract GetConstructorArgsWsETHBridgeL2UUPSProxy is Script {
   uint32 counterpartNetwork = 0; // zkEVM -> Ethereum
 
   // CREATE3 Factory
-  ICREATE3Factory factory =
-    ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
+  ICREATE3Factory factory = ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
 
   function setUp() public {
-    wrappedTokenAddress =
-      factory.getDeployed(deployerAddress, keccak256(bytes("WstETHWrapped")));
-    counterpartContract =
-      factory.getDeployed(deployerAddress, keccak256(bytes("WstETHBridgeL1")));
+    wrappedTokenAddress = factory.getDeployed(deployerAddress, keccak256(bytes("WstETHWrapped")));
+    counterpartContract = factory.getDeployed(deployerAddress, keccak256(bytes("WstETHBridgeL1")));
   }
 
   function run() public view {
@@ -44,8 +40,7 @@ contract GetConstructorArgsWsETHBridgeL2UUPSProxy is Script {
       counterpartContract,
       counterpartNetwork
     );
-    bytes memory args =
-      abi.encode(0x18FED1E19dC564DC917D203be9d40790472D22e9, data);
+    bytes memory args = abi.encode(0x18FED1E19dC564DC917D203be9d40790472D22e9, data);
     console.logBytes(args);
   }
 }

--- a/script/GetConstructorArgsWsETHWrappedUUPSProxy.s.sol
+++ b/script/GetConstructorArgsWsETHWrappedUUPSProxy.s.sol
@@ -13,14 +13,9 @@ contract GetConstructorArgsWsETHWrappedUUPSProxy is Script {
   address wstETHBridgeAddress = 0xDB5D9c10FD2a92692DB51853e06058EE0436d69B;
 
   function run() public view {
-    bytes memory data = abi.encodeWithSelector(
-      WstETHWrapped.initialize.selector,
-      adminAddress,
-      emergencyRoleAddress,
-      wstETHBridgeAddress
-    );
-    bytes memory args =
-      abi.encode(0xF2400233954CA016882D1fe3C1aC07c10719d719, data);
+    bytes memory data =
+      abi.encodeWithSelector(WstETHWrapped.initialize.selector, adminAddress, emergencyRoleAddress, wstETHBridgeAddress);
+    bytes memory args = abi.encode(0xF2400233954CA016882D1fe3C1aC07c10719d719, data);
     console.logBytes(args);
   }
 }

--- a/script/ICREATE3Factory.sol
+++ b/script/ICREATE3Factory.sol
@@ -2,11 +2,6 @@
 pragma solidity 0.8.17;
 
 interface ICREATE3Factory {
-  function getDeployed(address deployer, bytes32 salt)
-    external
-    returns (address);
-  function deploy(bytes32 salt, bytes memory creationCode)
-    external
-    payable
-    returns (address deployed);
+  function getDeployed(address deployer, bytes32 salt) external returns (address);
+  function deploy(bytes32 salt, bytes memory creationCode) external payable returns (address deployed);
 }

--- a/script/UUPSProxy.sol
+++ b/script/UUPSProxy.sol
@@ -4,7 +4,5 @@ pragma solidity 0.8.17;
 import {ERC1967Proxy} from "oz/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract UUPSProxy is ERC1967Proxy {
-  constructor(address _implementation, bytes memory _data)
-    ERC1967Proxy(_implementation, _data)
-  {}
+  constructor(address _implementation, bytes memory _data) ERC1967Proxy(_implementation, _data) {}
 }

--- a/src/NativeConverter.sol
+++ b/src/NativeConverter.sol
@@ -66,7 +66,7 @@ contract NativeConverter is AccessControlDefaultAdminRulesUpgradeable, PausableU
     _pause();
   }
 
-  function unpause() external virtual onlyRole(EMERGENCY_ROLE) {
+  function unpause() external virtual onlyRole(DEFAULT_ADMIN_ROLE) {
     _unpause();
   }
 

--- a/src/WstETHBridgeL1.sol
+++ b/src/WstETHBridgeL1.sol
@@ -98,7 +98,7 @@ contract WstETHBridgeL1 is
    * @notice Resume the bridge
    * @dev Only EMERGENCY_ROLE can resume the bridge
    */
-  function unpause() external virtual onlyRole(EMERGENCY_ROLE) {
+  function unpause() external virtual onlyRole(DEFAULT_ADMIN_ROLE) {
     _unpause();
   }
 

--- a/src/WstETHBridgeL1.sol
+++ b/src/WstETHBridgeL1.sol
@@ -7,12 +7,10 @@ import {SafeERC20} from "oz/token/ERC20/utils/SafeERC20.sol";
 import {UUPSUpgradeable} from "upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {AccessControlDefaultAdminRulesUpgradeable} from
   "upgradeable/access/AccessControlDefaultAdminRulesUpgradeable.sol";
-import {PausableUpgradeable} from
-  "upgradeable/security/PausableUpgradeable.sol";
+import {PausableUpgradeable} from "upgradeable/security/PausableUpgradeable.sol";
 
 import {IPolygonZkEVMBridge} from "./interfaces/IPolygonZkEVMBridge.sol";
-import {PolygonERC20BridgeLibUpgradeable} from
-  "./base/PolygonERC20BridgeLibUpgradeable.sol";
+import {PolygonERC20BridgeLibUpgradeable} from "./base/PolygonERC20BridgeLibUpgradeable.sol";
 
 /**
  * @title WstETHBridgeL1
@@ -66,9 +64,7 @@ contract WstETHBridgeL1 is
     __AccessControlDefaultAdminRules_init(3 days, _adminAddress);
     __UUPSUpgradeable_init();
     __Pausable_init();
-    __PolygonERC20BridgeLib_init(
-      _polygonZkEVMBridge, _counterpartContract, _counterpartNetwork
-    );
+    __PolygonERC20BridgeLib_init(_polygonZkEVMBridge, _counterpartContract, _counterpartNetwork);
 
     _grantRole(EMERGENCY_ROLE, _emergencyRoleAddress);
 
@@ -80,11 +76,7 @@ contract WstETHBridgeL1 is
    * @dev The WstETHBridgeL1 can only be upgraded by the owner
    * @param v new WstETHBridgeL1 implementation
    */
-  function _authorizeUpgrade(address v)
-    internal
-    override
-    onlyRole(DEFAULT_ADMIN_ROLE)
-  {}
+  function _authorizeUpgrade(address v) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
   /**
    * @notice Pause the bridge
@@ -106,12 +98,7 @@ contract WstETHBridgeL1 is
    * @dev Handle the reception of the tokens
    * @param amount Token amount
    */
-  function _receiveTokens(uint256 amount)
-    internal
-    virtual
-    override
-    whenNotPaused
-  {
+  function _receiveTokens(uint256 amount) internal virtual override whenNotPaused {
     originTokenAddress.safeTransferFrom(msg.sender, address(this), amount);
   }
 
@@ -121,12 +108,7 @@ contract WstETHBridgeL1 is
    * on the other network
    * @param amount Token amount
    */
-  function _transferTokens(address destinationAddress, uint256 amount)
-    internal
-    virtual
-    override
-    whenNotPaused
-  {
+  function _transferTokens(address destinationAddress, uint256 amount) internal virtual override whenNotPaused {
     originTokenAddress.safeTransfer(destinationAddress, amount);
   }
 }

--- a/src/WstETHBridgeL2.sol
+++ b/src/WstETHBridgeL2.sol
@@ -95,7 +95,7 @@ contract WstETHBridgeL2 is
    * @notice Resume the bridge
    * @dev Only EMERGENCY_ROLE can resume the bridge
    */
-  function unpause() external virtual onlyRole(EMERGENCY_ROLE) {
+  function unpause() external virtual onlyRole(DEFAULT_ADMIN_ROLE) {
     _unpause();
   }
 

--- a/src/WstETHBridgeL2.sol
+++ b/src/WstETHBridgeL2.sol
@@ -5,12 +5,10 @@ import {IERC20} from "oz/token/ERC20/IERC20.sol";
 import {UUPSUpgradeable} from "upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {AccessControlDefaultAdminRulesUpgradeable} from
   "upgradeable/access/AccessControlDefaultAdminRulesUpgradeable.sol";
-import {PausableUpgradeable} from
-  "upgradeable/security/PausableUpgradeable.sol";
+import {PausableUpgradeable} from "upgradeable/security/PausableUpgradeable.sol";
 
 import {IPolygonZkEVMBridge} from "./interfaces/IPolygonZkEVMBridge.sol";
-import {PolygonERC20BridgeLibUpgradeable} from
-  "./base/PolygonERC20BridgeLibUpgradeable.sol";
+import {PolygonERC20BridgeLibUpgradeable} from "./base/PolygonERC20BridgeLibUpgradeable.sol";
 import {WstETHWrapped} from "./WstETHWrapped.sol";
 
 /**
@@ -63,9 +61,7 @@ contract WstETHBridgeL2 is
     __AccessControlDefaultAdminRules_init(3 days, _adminAddress);
     __UUPSUpgradeable_init();
     __Pausable_init();
-    __PolygonERC20BridgeLib_init(
-      _polygonZkEVMBridge, _counterpartContract, _counterpartNetwork
-    );
+    __PolygonERC20BridgeLib_init(_polygonZkEVMBridge, _counterpartContract, _counterpartNetwork);
 
     _grantRole(EMERGENCY_ROLE, _emergencyRoleAddress);
 
@@ -77,11 +73,7 @@ contract WstETHBridgeL2 is
    * @dev The WstETHBridgeL2 can only be upgraded by the admin
    * @param v new WstETHBridgeL2 version
    */
-  function _authorizeUpgrade(address v)
-    internal
-    override
-    onlyRole(DEFAULT_ADMIN_ROLE)
-  {}
+  function _authorizeUpgrade(address v) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
   /**
    * @notice Pause the bridge
@@ -103,12 +95,7 @@ contract WstETHBridgeL2 is
    * @dev Handle the reception of the tokens
    * @param amount Token amount
    */
-  function _receiveTokens(uint256 amount)
-    internal
-    virtual
-    override
-    whenNotPaused
-  {
+  function _receiveTokens(uint256 amount) internal virtual override whenNotPaused {
     wrappedTokenAddress.bridgeBurn(msg.sender, amount);
   }
 
@@ -118,12 +105,7 @@ contract WstETHBridgeL2 is
    * on the other network
    * @param amount Token amount
    */
-  function _transferTokens(address destinationAddress, uint256 amount)
-    internal
-    virtual
-    override
-    whenNotPaused
-  {
+  function _transferTokens(address destinationAddress, uint256 amount) internal virtual override whenNotPaused {
     wrappedTokenAddress.bridgeMint(destinationAddress, amount);
   }
 }

--- a/src/WstETHWrapped.sol
+++ b/src/WstETHWrapped.sol
@@ -88,7 +88,7 @@ contract WstETHWrapped is
    * @notice Resume the WstETH
    * @dev Only EMERGENCY_ROLE can resume the bridge
    */
-  function unpause() external virtual onlyRole(EMERGENCY_ROLE) {
+  function unpause() external virtual onlyRole(DEFAULT_ADMIN_ROLE) {
     _unpause();
   }
 

--- a/src/WstETHWrapped.sol
+++ b/src/WstETHWrapped.sol
@@ -6,10 +6,8 @@ import {UUPSUpgradeable} from "upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {AccessControlDefaultAdminRulesUpgradeable} from
   "upgradeable/access/AccessControlDefaultAdminRulesUpgradeable.sol";
 
-import {PausableUpgradeable} from
-  "upgradeable/security/PausableUpgradeable.sol";
-import {ERC20PermitUpgradeable} from
-  "upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
+import {PausableUpgradeable} from "upgradeable/security/PausableUpgradeable.sol";
+import {ERC20PermitUpgradeable} from "upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
 
 /**
  * @title WstETHWrapped
@@ -40,10 +38,7 @@ contract WstETHWrapped is
    * @dev Modifier to make sure the caller is a bridge
    */
   modifier onlyBridge() {
-    require(
-      msg.sender == wstETHBridge,
-      "CustomERC20Wrapped::onlyBridge: Not PolygonZkEVMBridge"
-    );
+    require(msg.sender == wstETHBridge, "CustomERC20Wrapped::onlyBridge: Not PolygonZkEVMBridge");
     _;
   }
 
@@ -53,11 +48,10 @@ contract WstETHWrapped is
    * @param _emergencyRoleAddress The emergency role address
    * @param _wstETHBridgeAddress The WstETH bridge address on Polygon zkEVM
    */
-  function initialize(
-    address _adminAddress,
-    address _emergencyRoleAddress,
-    address _wstETHBridgeAddress
-  ) public initializer {
+  function initialize(address _adminAddress, address _emergencyRoleAddress, address _wstETHBridgeAddress)
+    public
+    initializer
+  {
     __AccessControlDefaultAdminRules_init(3 days, _adminAddress);
     __UUPSUpgradeable_init();
     __ERC20_init("Wrapped liquid staked Ether 2.0", "wstETH");
@@ -70,11 +64,7 @@ contract WstETHWrapped is
    * @dev The WstETH can only be upgraded by the admin
    * @param v new WstETH version
    */
-  function _authorizeUpgrade(address v)
-    internal
-    override
-    onlyRole(DEFAULT_ADMIN_ROLE)
-  {}
+  function _authorizeUpgrade(address v) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
 
   /**
    * @notice Pause the WstETH
@@ -95,12 +85,7 @@ contract WstETHWrapped is
   /**
    * @notice _beforeTokenTransfer hook to pause the transfer
    */
-  function _beforeTokenTransfer(address from, address to, uint256 amount)
-    internal
-    virtual
-    override
-    whenNotPaused
-  {
+  function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override whenNotPaused {
     super._beforeTokenTransfer(from, to, amount);
   }
 

--- a/src/WstETHWrappedV2.sol
+++ b/src/WstETHWrappedV2.sol
@@ -13,10 +13,7 @@ contract WstETHWrappedV2 is WstETHWrapped {
   }
 
   /// @notice Function to add/update a new minter
-  function addMinter(address minter, uint256 allowance)
-    external
-    onlyRole(EMERGENCY_ROLE)
-  {
+  function addMinter(address minter, uint256 allowance) external onlyRole(EMERGENCY_ROLE) {
     minters[minter] = true;
     minterAllowance[minter] = allowance;
   }

--- a/src/WstETHWrappedV2.sol
+++ b/src/WstETHWrappedV2.sol
@@ -13,13 +13,13 @@ contract WstETHWrappedV2 is WstETHWrapped {
   }
 
   /// @notice Function to add/update a new minter
-  function addMinter(address minter, uint256 allowance) external onlyRole(EMERGENCY_ROLE) {
+  function addMinter(address minter, uint256 allowance) external onlyRole(DEFAULT_ADMIN_ROLE) {
     minters[minter] = true;
     minterAllowance[minter] = allowance;
   }
 
   /// @notice Function to remove a minter
-  function removeMinter(address minter) external onlyRole(EMERGENCY_ROLE) {
+  function removeMinter(address minter) external onlyRole(DEFAULT_ADMIN_ROLE) {
     delete minters[minter];
     delete minterAllowance[minter];
   }

--- a/src/base/PolygonBridgeLibUpgradeable.sol
+++ b/src/base/PolygonBridgeLibUpgradeable.sol
@@ -29,9 +29,7 @@ abstract contract PolygonBridgeLibUpgradeable is Initializable {
     address _counterpartContract,
     uint32 _counterpartNetwork
   ) internal onlyInitializing {
-    __PolygonBridgeLib_init_unchained(
-      _polygonZkEVMBridge, _counterpartContract, _counterpartNetwork
-    );
+    __PolygonBridgeLib_init_unchained(_polygonZkEVMBridge, _counterpartContract, _counterpartNetwork);
   }
 
   function __PolygonBridgeLib_init_unchained(
@@ -50,16 +48,8 @@ abstract contract PolygonBridgeLibUpgradeable is Initializable {
    * @param forceUpdateGlobalExitRoot Indicates if the global exit root is
    * updated or not
    */
-  function _bridgeMessage(
-    bytes memory messageData,
-    bool forceUpdateGlobalExitRoot
-  ) internal virtual {
-    polygonZkEVMBridge.bridgeMessage(
-      counterpartNetwork,
-      counterpartContract,
-      forceUpdateGlobalExitRoot,
-      messageData
-    );
+  function _bridgeMessage(bytes memory messageData, bool forceUpdateGlobalExitRoot) internal virtual {
+    polygonZkEVMBridge.bridgeMessage(counterpartNetwork, counterpartContract, forceUpdateGlobalExitRoot, messageData);
   }
 
   /**
@@ -70,25 +60,12 @@ abstract contract PolygonBridgeLibUpgradeable is Initializable {
    * usefull for this contract )
    * @param data Abi encoded metadata
    */
-  function onMessageReceived(
-    address originAddress,
-    uint32 originNetwork,
-    bytes memory data
-  ) external payable {
+  function onMessageReceived(address originAddress, uint32 originNetwork, bytes memory data) external payable {
     // Can only be called by the bridge
-    require(
-      msg.sender == address(polygonZkEVMBridge),
-      "TokenWrapped::PolygonBridgeLib: Not PolygonZkEVMBridge"
-    );
+    require(msg.sender == address(polygonZkEVMBridge), "TokenWrapped::PolygonBridgeLib: Not PolygonZkEVMBridge");
 
-    require(
-      counterpartContract == originAddress,
-      "TokenWrapped::PolygonBridgeLib: Not counterpart contract"
-    );
-    require(
-      counterpartNetwork == originNetwork,
-      "TokenWrapped::PolygonBridgeLib: Not counterpart network"
-    );
+    require(counterpartContract == originAddress, "TokenWrapped::PolygonBridgeLib: Not counterpart contract");
+    require(counterpartNetwork == originNetwork, "TokenWrapped::PolygonBridgeLib: Not counterpart network");
 
     _onMessageReceived(data);
   }

--- a/src/base/PolygonERC20BridgeLibUpgradeable.sol
+++ b/src/base/PolygonERC20BridgeLibUpgradeable.sol
@@ -11,9 +11,7 @@ import "./PolygonBridgeLibUpgradeable.sol";
  *
  * https://github.com/0xPolygonHermez/code-examples/blob/main/customERC20-bridge-example/contracts/lib/PolygonERC20BridgeLib.sol
  */
-abstract contract PolygonERC20BridgeLibUpgradeable is
-  PolygonBridgeLibUpgradeable
-{
+abstract contract PolygonERC20BridgeLibUpgradeable is PolygonBridgeLibUpgradeable {
   /**
    * Sets bridge values
    * @param _polygonZkEVMBridge Polygon zkEVM bridge address
@@ -25,9 +23,7 @@ abstract contract PolygonERC20BridgeLibUpgradeable is
     address _counterpartContract,
     uint32 _counterpartNetwork
   ) internal onlyInitializing {
-    __PolygonBridgeLib_init_unchained(
-      _polygonZkEVMBridge, _counterpartContract, _counterpartNetwork
-    );
+    __PolygonBridgeLib_init_unchained(_polygonZkEVMBridge, _counterpartContract, _counterpartNetwork);
   }
 
   function __PolygonERC20BridgeLib_init_unchained(
@@ -57,11 +53,7 @@ abstract contract PolygonERC20BridgeLibUpgradeable is
    * @param forceUpdateGlobalExitRoot Indicates if the global exit root is
    * updated or not
    */
-  function bridgeToken(
-    address destinationAddress,
-    uint256 amount,
-    bool forceUpdateGlobalExitRoot
-  ) external {
+  function bridgeToken(address destinationAddress, uint256 amount, bool forceUpdateGlobalExitRoot) external {
     _receiveTokens(amount);
 
     // Encode message data
@@ -80,8 +72,7 @@ abstract contract PolygonERC20BridgeLibUpgradeable is
    */
   function _onMessageReceived(bytes memory data) internal override {
     // Decode message data
-    (address destinationAddress, uint256 amount) =
-      abi.decode(data, (address, uint256));
+    (address destinationAddress, uint256 amount) = abi.decode(data, (address, uint256));
 
     _transferTokens(destinationAddress, amount);
     emit ClaimTokens(destinationAddress, amount);
@@ -97,9 +88,7 @@ abstract contract PolygonERC20BridgeLibUpgradeable is
    * @dev Handle the transfer of the tokens
    * Must be implemented in parent contracts
    */
-  function _transferTokens(address destinationAddress, uint256 amount)
-    internal
-    virtual;
+  function _transferTokens(address destinationAddress, uint256 amount) internal virtual;
 
   // https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#storage-gaps
   uint256[50] private __gap;

--- a/src/interfaces/ICREATE3Factory.sol
+++ b/src/interfaces/ICREATE3Factory.sol
@@ -2,11 +2,6 @@
 pragma solidity 0.8.17;
 
 interface ICREATE3Factory {
-  function getDeployed(address deployer, bytes32 salt)
-    external
-    returns (address);
-  function deploy(bytes32 salt, bytes memory creationCode)
-    external
-    payable
-    returns (address deployed);
+  function getDeployed(address deployer, bytes32 salt) external returns (address);
+  function deploy(bytes32 salt, bytes memory creationCode) external payable returns (address deployed);
 }

--- a/src/interfaces/IPolygonZkEVMBridge.sol
+++ b/src/interfaces/IPolygonZkEVMBridge.sol
@@ -77,9 +77,12 @@ interface IPolygonZkEVMBridge {
     bytes calldata permitData
   ) external payable;
 
-  function bridgeMessage(uint32 destinationNetwork, address destinationAddress, bool forceUpdateGlobalExitRoot, bytes calldata metadata)
-    external
-    payable;
+  function bridgeMessage(
+    uint32 destinationNetwork,
+    address destinationAddress,
+    bool forceUpdateGlobalExitRoot,
+    bytes calldata metadata
+  ) external payable;
 
   function claimAsset(
     bytes32[32] calldata smtProof,

--- a/src/proxies/NativeConverterUUPSProxy.sol
+++ b/src/proxies/NativeConverterUUPSProxy.sol
@@ -4,7 +4,5 @@ pragma solidity 0.8.17;
 import {ERC1967Proxy} from "oz/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract NativeConverterUUPSProxy is ERC1967Proxy {
-  constructor(address _implementation, bytes memory _data)
-    ERC1967Proxy(_implementation, _data)
-  {}
+  constructor(address _implementation, bytes memory _data) ERC1967Proxy(_implementation, _data) {}
 }

--- a/src/proxies/WstETHBridgeL1UUPSProxy.sol
+++ b/src/proxies/WstETHBridgeL1UUPSProxy.sol
@@ -9,7 +9,5 @@ import {ERC1967Proxy} from "oz/proxy/ERC1967/ERC1967Proxy.sol";
  * @notice UUPS proxy smart contract
  */
 contract WstETHBridgeL1UUPSProxy is ERC1967Proxy {
-  constructor(address _implementation, bytes memory _data)
-    ERC1967Proxy(_implementation, _data)
-  {}
+  constructor(address _implementation, bytes memory _data) ERC1967Proxy(_implementation, _data) {}
 }

--- a/src/proxies/WstETHBridgeL2UUPSProxy.sol
+++ b/src/proxies/WstETHBridgeL2UUPSProxy.sol
@@ -9,7 +9,5 @@ import {ERC1967Proxy} from "oz/proxy/ERC1967/ERC1967Proxy.sol";
  * @notice UUPS proxy smart contract
  */
 contract WstETHBridgeL2UUPSProxy is ERC1967Proxy {
-  constructor(address _implementation, bytes memory _data)
-    ERC1967Proxy(_implementation, _data)
-  {}
+  constructor(address _implementation, bytes memory _data) ERC1967Proxy(_implementation, _data) {}
 }

--- a/src/proxies/WstETHWrappedUUPSProxy.sol
+++ b/src/proxies/WstETHWrappedUUPSProxy.sol
@@ -9,7 +9,5 @@ import {ERC1967Proxy} from "oz/proxy/ERC1967/ERC1967Proxy.sol";
  * @notice UUPS proxy smart contract
  */
 contract WstETHWrappedUUPSProxy is ERC1967Proxy {
-  constructor(address _implementation, bytes memory _data)
-    ERC1967Proxy(_implementation, _data)
-  {}
+  constructor(address _implementation, bytes memory _data) ERC1967Proxy(_implementation, _data) {}
 }

--- a/test/NativeConverter.t.sol
+++ b/test/NativeConverter.t.sol
@@ -66,7 +66,7 @@ contract NativeConverterTest is Test {
     vm.stopPrank();
 
     // configure native converter to be a minter with 1B allowance
-    vm.startPrank(_emergency);
+    vm.startPrank(_admin);
     _nativeWstEthV2.addMinter(address(_nativeConverter), 10 ** 9 * 10 ** 18);
     vm.stopPrank();
   }

--- a/test/NativeConverter.t.sol
+++ b/test/NativeConverter.t.sol
@@ -9,10 +9,8 @@ import {NativeConverter} from "../src/NativeConverter.sol";
 import {WstETHWrapped} from "../src/WstETHWrapped.sol";
 import {WstETHWrappedV2} from "../src/WstETHWrappedV2.sol";
 
-import {NativeConverterUUPSProxy} from
-  "../src/proxies/NativeConverterUUPSProxy.sol";
-import {WstETHWrappedUUPSProxy} from
-  "../src/proxies/WstETHWrappedUUPSProxy.sol";
+import {NativeConverterUUPSProxy} from "../src/proxies/NativeConverterUUPSProxy.sol";
+import {WstETHWrappedUUPSProxy} from "../src/proxies/WstETHWrappedUUPSProxy.sol";
 
 contract NativeConverterTest is Test {
   address _bridge = 0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe;
@@ -111,9 +109,7 @@ contract NativeConverterTest is Test {
     // bob has 800k bridge-wrapped wstETH
     assertEq(_bwWstETH.balanceOf(_bob), amount);
     // native converter has 200k bridge-wrapped wstETH
-    assertEq(
-      _bwWstETH.balanceOf(address(_nativeConverter)), 200_000 * 10 ** 18
-    );
+    assertEq(_bwWstETH.balanceOf(address(_nativeConverter)), 200_000 * 10 ** 18);
   }
 
   function testOwnerCanMigrate() external {

--- a/test/NativeConverter.t.sol
+++ b/test/NativeConverter.t.sol
@@ -144,7 +144,7 @@ contract NativeConverterTest is Test {
     vm.stopPrank();
   }
 
-  function testOwnerCanPauseUnpause() external {
+  function testEmergencyCanPauseDefaultAdminCanUnpause() external {
     vm.startPrank(_emergency);
 
     // unpaused, pause
@@ -152,7 +152,16 @@ contract NativeConverterTest is Test {
     _nativeConverter.pause();
     assertEq(_nativeConverter.paused(), true);
 
-    // paused, unpause
+    // paused, emergency CANNOT unpause
+    vm.expectRevert(
+      "AccessControl: account 0x14a1e1e4d8bea80c96edcaf655b8d1f35682c069 is missing role 0x0000000000000000000000000000000000000000000000000000000000000000"
+    );
+    _nativeConverter.unpause();
+    assertEq(_nativeConverter.paused(), true);
+    vm.stopPrank();
+
+    // paused, default admin CAN unpause
+    vm.startPrank(_admin);
     _nativeConverter.unpause();
     assertEq(_nativeConverter.paused(), false);
 
@@ -179,7 +188,7 @@ contract NativeConverterTest is Test {
     // paused, try to unpause, fail
     changePrank(_alice);
     vm.expectRevert(
-      "AccessControl: account 0xe05fcc23807536bee418f142d19fa0d21bb0cff7 is missing role 0xbf233dd2aafeb4d50879c4aa5c81e96d92f6e6945c906a58f9f2d1c1631b4b26"
+      "AccessControl: account 0xe05fcc23807536bee418f142d19fa0d21bb0cff7 is missing role 0x0000000000000000000000000000000000000000000000000000000000000000"
     );
     _nativeConverter.unpause();
     assertEq(_nativeConverter.paused(), true);

--- a/test/WstETHBridgeL1.t.sol
+++ b/test/WstETHBridgeL1.t.sol
@@ -7,8 +7,7 @@ import {IERC20} from "oz/token/ERC20/IERC20.sol";
 import {ICREATE3Factory} from "../src/interfaces/ICREATE3Factory.sol";
 
 import {WstETHBridgeL1} from "../src/WstETHBridgeL1.sol";
-import {WstETHBridgeL1UUPSProxy} from
-  "../src/proxies/WstETHBridgeL1UUPSProxy.sol";
+import {WstETHBridgeL1UUPSProxy} from "../src/proxies/WstETHBridgeL1UUPSProxy.sol";
 
 /**
  * @title WstETHBridgeL1V2Mock
@@ -37,8 +36,7 @@ contract WstETHBridgeL1V2Mock is WstETHBridgeL1 {
 contract WstETHBridgeL1Test is Test {
   string ETH_RPC_URL = vm.envString("ETH_RPC_URL");
 
-  ICREATE3Factory create3Factory =
-    ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
+  ICREATE3Factory create3Factory = ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
 
   address deployer = vm.addr(0xC14C13);
   address admin = vm.addr(0xB453D);
@@ -50,13 +48,11 @@ contract WstETHBridgeL1Test is Test {
   WstETHBridgeL1 bridgeL1;
 
   function _getWstETHBridgeL2Address() internal returns (address) {
-    return
-      create3Factory.getDeployed(deployer, keccak256(bytes("WstETHBridgeL2")));
+    return create3Factory.getDeployed(deployer, keccak256(bytes("WstETHBridgeL2")));
   }
 
   function _getWstETHWrappedAddress() internal returns (address) {
-    return
-      create3Factory.getDeployed(deployer, keccak256(bytes("WstETHWrapped")));
+    return create3Factory.getDeployed(deployer, keccak256(bytes("WstETHWrapped")));
   }
 
   function _deployWstETHBridgeL1() internal returns (WstETHBridgeL1 bridge) {
@@ -79,10 +75,8 @@ contract WstETHBridgeL1Test is Test {
       counterpartNetwork
     );
     bytes32 salt = keccak256(bytes("WstETHBridgeL1"));
-    bytes memory creationCode = abi.encodePacked(
-      type(WstETHBridgeL1UUPSProxy).creationCode,
-      abi.encode(address(implementation), data)
-    );
+    bytes memory creationCode =
+      abi.encodePacked(type(WstETHBridgeL1UUPSProxy).creationCode, abi.encode(address(implementation), data));
     address deployedAddress = create3Factory.deploy(salt, creationCode);
     bridge = WstETHBridgeL1(deployedAddress);
 

--- a/test/WstETHBridgeL2.t.sol
+++ b/test/WstETHBridgeL2.t.sol
@@ -5,12 +5,10 @@ import {Test} from "forge-std/Test.sol";
 
 import {ICREATE3Factory} from "../src/interfaces/ICREATE3Factory.sol";
 import {WstETHWrapped} from "../src/WstETHWrapped.sol";
-import {WstETHWrappedUUPSProxy} from
-  "../src/proxies/WstETHWrappedUUPSProxy.sol";
+import {WstETHWrappedUUPSProxy} from "../src/proxies/WstETHWrappedUUPSProxy.sol";
 
 import {WstETHBridgeL2} from "../src/WstETHBridgeL2.sol";
-import {WstETHBridgeL2UUPSProxy} from
-  "../src/proxies/WstETHBridgeL2UUPSProxy.sol";
+import {WstETHBridgeL2UUPSProxy} from "../src/proxies/WstETHBridgeL2UUPSProxy.sol";
 
 /**
  * @title WstETHBridgeL2V2Mock
@@ -39,8 +37,7 @@ contract WstETHBridgeL2V2Mock is WstETHBridgeL2 {
 contract WstETHBridgeL2Test is Test {
   string ZKEVM_RPC_URL = vm.envString("ZKEVM_RPC_URL");
 
-  ICREATE3Factory create3Factory =
-    ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
+  ICREATE3Factory create3Factory = ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
 
   address deployer = vm.addr(0xC14C13);
   address admin = vm.addr(0xB453D);
@@ -53,18 +50,15 @@ contract WstETHBridgeL2Test is Test {
   WstETHBridgeL2 bridgeL2;
 
   function _getWstETHWrappedAddress() internal returns (address) {
-    return
-      create3Factory.getDeployed(deployer, keccak256(bytes("WstETHWrapped")));
+    return create3Factory.getDeployed(deployer, keccak256(bytes("WstETHWrapped")));
   }
 
   function _getWstETHBridgeL2Address() internal returns (address) {
-    return
-      create3Factory.getDeployed(deployer, keccak256(bytes("WstETHBridgeL2")));
+    return create3Factory.getDeployed(deployer, keccak256(bytes("WstETHBridgeL2")));
   }
 
   function _getWstETHBridgeL1Address() internal returns (address) {
-    return
-      create3Factory.getDeployed(deployer, keccak256(bytes("WstETHBridgeL1")));
+    return create3Factory.getDeployed(deployer, keccak256(bytes("WstETHBridgeL1")));
   }
 
   function _deployWstETHWrapped() internal returns (WstETHWrapped token) {
@@ -72,14 +66,10 @@ contract WstETHBridgeL2Test is Test {
 
     address wstETHBridgeAddress = _getWstETHBridgeL2Address();
     WstETHWrapped implementation = new WstETHWrapped();
-    bytes memory data = abi.encodeWithSelector(
-      WstETHWrapped.initialize.selector, admin, emergency, wstETHBridgeAddress
-    );
+    bytes memory data = abi.encodeWithSelector(WstETHWrapped.initialize.selector, admin, emergency, wstETHBridgeAddress);
     bytes32 salt = keccak256(bytes("WstETHWrapped"));
-    bytes memory creationCode = abi.encodePacked(
-      type(WstETHWrappedUUPSProxy).creationCode,
-      abi.encode(address(implementation), data)
-    );
+    bytes memory creationCode =
+      abi.encodePacked(type(WstETHWrappedUUPSProxy).creationCode, abi.encode(address(implementation), data));
     address deployedAddress = create3Factory.deploy(salt, creationCode);
     token = WstETHWrapped(deployedAddress);
 
@@ -106,10 +96,8 @@ contract WstETHBridgeL2Test is Test {
       counterpartNetwork
     );
     bytes32 salt = keccak256(bytes("WstETHBridgeL2"));
-    bytes memory creationCode = abi.encodePacked(
-      type(WstETHBridgeL2UUPSProxy).creationCode,
-      abi.encode(address(implementation), data)
-    );
+    bytes memory creationCode =
+      abi.encodePacked(type(WstETHBridgeL2UUPSProxy).creationCode, abi.encode(address(implementation), data));
     address deployedAddress = create3Factory.deploy(salt, creationCode);
     bridge = WstETHBridgeL2(deployedAddress);
 

--- a/test/WstETHWrapped.t.sol
+++ b/test/WstETHWrapped.t.sol
@@ -5,8 +5,7 @@ import {Test} from "forge-std/Test.sol";
 
 import {ICREATE3Factory} from "../src/interfaces/ICREATE3Factory.sol";
 import {WstETHWrapped} from "../src/WstETHWrapped.sol";
-import {WstETHWrappedUUPSProxy} from
-  "../src/proxies/WstETHWrappedUUPSProxy.sol";
+import {WstETHWrappedUUPSProxy} from "../src/proxies/WstETHWrappedUUPSProxy.sol";
 
 /**
  * @title WstETHV2Mock
@@ -35,8 +34,7 @@ contract WstETHWrappedV2Mock is WstETHWrapped {
 contract WstETHWrappedTest is Test {
   string ZKEVM_RPC_URL = vm.envString("ZKEVM_RPC_URL");
 
-  ICREATE3Factory create3Factory =
-    ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
+  ICREATE3Factory create3Factory = ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
 
   address deployer = vm.addr(0xC14C13);
   address admin = vm.addr(0xB453D);
@@ -48,8 +46,7 @@ contract WstETHWrappedTest is Test {
   WstETHWrapped wrappedToken;
 
   function _getWstETHBridgeL2Address() internal returns (address) {
-    return
-      create3Factory.getDeployed(deployer, keccak256(bytes("WstETHBridgeL2")));
+    return create3Factory.getDeployed(deployer, keccak256(bytes("WstETHBridgeL2")));
   }
 
   function _deployWstETHWrapped() internal returns (WstETHWrapped token) {
@@ -57,14 +54,10 @@ contract WstETHWrappedTest is Test {
 
     wstETHBridgeAddress = _getWstETHBridgeL2Address();
     WstETHWrapped implementation = new WstETHWrapped();
-    bytes memory data = abi.encodeWithSelector(
-      WstETHWrapped.initialize.selector, admin, emergency, wstETHBridgeAddress
-    );
+    bytes memory data = abi.encodeWithSelector(WstETHWrapped.initialize.selector, admin, emergency, wstETHBridgeAddress);
     bytes32 salt = keccak256(bytes("WstETHWrapped"));
-    bytes memory creationCode = abi.encodePacked(
-      type(WstETHWrappedUUPSProxy).creationCode,
-      abi.encode(address(implementation), data)
-    );
+    bytes memory creationCode =
+      abi.encodePacked(type(WstETHWrappedUUPSProxy).creationCode, abi.encode(address(implementation), data));
     address deployedAddress = create3Factory.deploy(salt, creationCode);
     token = WstETHWrapped(deployedAddress);
 
@@ -91,8 +84,7 @@ contract WstETHWrappedTest is Test {
     wrappedToken.upgradeTo(address(v2));
     vm.stopPrank();
 
-    WstETHWrappedV2Mock wrappedTokenV2 =
-      WstETHWrappedV2Mock(address(wrappedToken));
+    WstETHWrappedV2Mock wrappedTokenV2 = WstETHWrappedV2Mock(address(wrappedToken));
     wrappedTokenV2.setValue(2);
     assertEq(wrappedTokenV2.getValue(), 2);
   }

--- a/test/WstETHWrappedV2.t.sol
+++ b/test/WstETHWrappedV2.t.sol
@@ -5,8 +5,7 @@ import {Test} from "forge-std/Test.sol";
 
 import {WstETHWrapped} from "../src/WstETHWrapped.sol";
 import {WstETHWrappedV2} from "../src/WstETHWrappedV2.sol";
-import {WstETHWrappedUUPSProxy} from
-  "../src/proxies/WstETHWrappedUUPSProxy.sol";
+import {WstETHWrappedUUPSProxy} from "../src/proxies/WstETHWrappedUUPSProxy.sol";
 
 contract WstETHWrappedTestV2 is Test {
   address _bridge = 0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe;

--- a/test/WstETHWrappedV2.t.sol
+++ b/test/WstETHWrappedV2.t.sol
@@ -42,7 +42,7 @@ contract WstETHWrappedTestV2 is Test {
     vm.stopPrank();
 
     // owner sets minter
-    vm.startPrank(_emergency);
+    vm.startPrank(_admin);
     _wstEthV2.addMinter(_minter, 10 ** 6 * 10 ** 18); // 1M wstETH allowance
     vm.stopPrank();
 
@@ -57,7 +57,7 @@ contract WstETHWrappedTestV2 is Test {
 
   function testOwnerCanRemoveMinter() external {
     // owner sets minter
-    vm.startPrank(_emergency);
+    vm.startPrank(_admin);
     _wstEthV2.addMinter(_minter, 10 ** 6 * 10 ** 18); // 1M wstETH allowance
     vm.stopPrank();
 
@@ -70,7 +70,7 @@ contract WstETHWrappedTestV2 is Test {
     assertEq(_wstEthV2.balanceOf(_joe), 1000 * 10 ** 18);
 
     // owner removes minter
-    vm.startPrank(_emergency);
+    vm.startPrank(_admin);
     _wstEthV2.removeMinter(_minter);
     vm.stopPrank();
 
@@ -85,7 +85,7 @@ contract WstETHWrappedTestV2 is Test {
     // trying to make itself a minter
     vm.startPrank(_minter);
     vm.expectRevert(
-      "AccessControl: account 0xe05fcc23807536bee418f142d19fa0d21bb0cff7 is missing role 0xbf233dd2aafeb4d50879c4aa5c81e96d92f6e6945c906a58f9f2d1c1631b4b26"
+      "AccessControl: account 0xe05fcc23807536bee418f142d19fa0d21bb0cff7 is missing role 0x0000000000000000000000000000000000000000000000000000000000000000"
     );
     _wstEthV2.addMinter(_minter, 10 ** 6 * 10 ** 18); // 1M DAI
     vm.stopPrank();
@@ -93,14 +93,14 @@ contract WstETHWrappedTestV2 is Test {
 
   function testNonOwnerCannotRemoveMinter() external {
     // owner sets minter
-    vm.startPrank(_emergency);
+    vm.startPrank(_admin);
     _wstEthV2.addMinter(_minter, 10 ** 6 * 10 ** 18); // 1M wstETH allowance
     vm.stopPrank();
 
     // non-owner tries to remove minter
     vm.startPrank(_minter);
     vm.expectRevert(
-      "AccessControl: account 0xe05fcc23807536bee418f142d19fa0d21bb0cff7 is missing role 0xbf233dd2aafeb4d50879c4aa5c81e96d92f6e6945c906a58f9f2d1c1631b4b26"
+      "AccessControl: account 0xe05fcc23807536bee418f142d19fa0d21bb0cff7 is missing role 0x0000000000000000000000000000000000000000000000000000000000000000"
     );
     _wstEthV2.removeMinter(_minter);
     vm.stopPrank();
@@ -108,7 +108,7 @@ contract WstETHWrappedTestV2 is Test {
 
   function testMinterCannotMintOverAllowance() external {
     // owner sets minter
-    vm.startPrank(_emergency);
+    vm.startPrank(_admin);
     _wstEthV2.addMinter(_minter, 10 ** 6 * 10 ** 18); // 1M wstETH allowance
     vm.stopPrank();
 
@@ -134,7 +134,7 @@ contract WstETHWrappedTestV2 is Test {
 
   function testMinterCanBurn() external {
     // owner sets minter
-    vm.startPrank(_emergency);
+    vm.startPrank(_admin);
     _wstEthV2.addMinter(_minter, 10 ** 6 * 10 ** 18); // 1M wstETH allowance
     vm.stopPrank();
 


### PR DESCRIPTION
these changes were requested by the Lido team

- change unpause to be only executable by the default admin role (instead of emergency)
- change add/remove minters to be only executable by the default admin role (instead of emergency)
